### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,9 @@
+# version 1.1.0
+- This does **not break** compatibility with 1.0.0 
+- Add interface `CreatableFromArrayInterface` that enforces an static method create(array): $this
+- Add interface `ExportableToArrayInterface` that enforces an method toArray(): array
+- Add trait `StaticCreateIgnoreCaseTrait` is the same as `StaticCreateTrait` but ignore case on keys
+- More test for all changes
+
 # version 1.0.0
 - First public release

--- a/src/ConstructNamedParameters/Contracts/CreatableFromArrayInterface.php
+++ b/src/ConstructNamedParameters/Contracts/CreatableFromArrayInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace ConstructNamedParameters\Contracts;
 
 interface CreatableFromArrayInterface

--- a/src/ConstructNamedParameters/Contracts/CreatableFromArrayInterface.php
+++ b/src/ConstructNamedParameters/Contracts/CreatableFromArrayInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConstructNamedParameters\Contracts;
+
+interface CreatableFromArrayInterface
+{
+    /**
+     * Create an instance of the object based on the key and values from the array
+     *
+     * @param array $values
+     *
+     * @return $this
+     */
+    public static function create(array $values);
+}

--- a/src/ConstructNamedParameters/Contracts/ExportableToArrayInterface.php
+++ b/src/ConstructNamedParameters/Contracts/ExportableToArrayInterface.php
@@ -8,5 +8,5 @@ interface ExportableToArrayInterface
      *
      * @return array
      */
-    public static function toArray();
+    public function toArray();
 }

--- a/src/ConstructNamedParameters/Contracts/ExportableToArrayInterface.php
+++ b/src/ConstructNamedParameters/Contracts/ExportableToArrayInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace ConstructNamedParameters\Contracts;
 
 interface ExportableToArrayInterface

--- a/src/ConstructNamedParameters/Contracts/ExportableToArrayInterface.php
+++ b/src/ConstructNamedParameters/Contracts/ExportableToArrayInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConstructNamedParameters\Contracts;
+
+interface ExportableToArrayInterface
+{
+    /**
+     * Return an array with properties as key values
+     *
+     * @return array
+     */
+    public static function toArray();
+}

--- a/src/ConstructNamedParameters/Traits/StaticCreateIgnoreCaseTrait.php
+++ b/src/ConstructNamedParameters/Traits/StaticCreateIgnoreCaseTrait.php
@@ -1,0 +1,17 @@
+<?php
+namespace ConstructNamedParameters\Traits;
+
+trait StaticCreateIgnoreCaseTrait
+{
+    /**
+     * Create an instance of the current object based on named parameters
+     *
+     * @param array $values
+     *
+     * @return $this
+     */
+    public static function create(array $values)
+    {
+        return construct_named_parameters_uncase(static::class, $values);
+    }
+}

--- a/src/ConstructNamedParameters/Traits/StaticCreateTrait.php
+++ b/src/ConstructNamedParameters/Traits/StaticCreateTrait.php
@@ -12,6 +12,6 @@ trait StaticCreateTrait
      */
     public static function create(array $values)
     {
-        return \ConstructNamedParameters\Builder::create(static::class, $values);
+        return construct_named_parameters(static::class, $values);
     }
 }

--- a/tests/ConstructNamedParameters/Samples/ArrayableInvoice.php
+++ b/tests/ConstructNamedParameters/Samples/ArrayableInvoice.php
@@ -1,9 +1,10 @@
 <?php
 namespace Tests\ConstructNamedParameters\Samples;
 
+use ConstructNamedParameters\Contracts\ExportableToArrayInterface;
 use ConstructNamedParameters\Traits\ToArrayTrait;
 
-class ArrayableInvoice
+class ArrayableInvoice implements ExportableToArrayInterface
 {
     use ToArrayTrait;
 

--- a/tests/ConstructNamedParameters/Samples/ArrayableLine.php
+++ b/tests/ConstructNamedParameters/Samples/ArrayableLine.php
@@ -1,9 +1,10 @@
 <?php
 namespace Tests\ConstructNamedParameters\Samples;
 
+use ConstructNamedParameters\Contracts\ExportableToArrayInterface;
 use ConstructNamedParameters\Traits\ToArrayTrait;
 
-class ArrayableLine
+class ArrayableLine implements ExportableToArrayInterface
 {
     use ToArrayTrait;
 

--- a/tests/ConstructNamedParameters/Samples/BarCreatable.php
+++ b/tests/ConstructNamedParameters/Samples/BarCreatable.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Tests\ConstructNamedParameters\Samples;
 
 use ConstructNamedParameters\Traits\StaticCreateIgnoreCaseTrait;

--- a/tests/ConstructNamedParameters/Samples/BarCreatable.php
+++ b/tests/ConstructNamedParameters/Samples/BarCreatable.php
@@ -1,9 +1,10 @@
 <?php
 namespace Tests\ConstructNamedParameters\Samples;
 
+use ConstructNamedParameters\Contracts\CreatableFromArrayInterface;
 use ConstructNamedParameters\Traits\StaticCreateIgnoreCaseTrait;
 
-class BarCreatable extends BarWithCaseArguments
+class BarCreatable extends BarWithCaseArguments implements CreatableFromArrayInterface
 {
     use StaticCreateIgnoreCaseTrait;
 }

--- a/tests/ConstructNamedParameters/Samples/BarCreatable.php
+++ b/tests/ConstructNamedParameters/Samples/BarCreatable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\ConstructNamedParameters\Samples;
+
+use ConstructNamedParameters\Traits\StaticCreateIgnoreCaseTrait;
+
+class BarCreatable extends BarWithCaseArguments
+{
+    use StaticCreateIgnoreCaseTrait;
+}

--- a/tests/ConstructNamedParameters/Samples/FooCreatable.php
+++ b/tests/ConstructNamedParameters/Samples/FooCreatable.php
@@ -1,9 +1,10 @@
 <?php
 namespace Tests\ConstructNamedParameters\Samples;
 
+use ConstructNamedParameters\Contracts\CreatableFromArrayInterface;
 use ConstructNamedParameters\Traits\StaticCreateTrait;
 
-class FooCreatable extends Foo
+class FooCreatable extends Foo implements CreatableFromArrayInterface
 {
     use StaticCreateTrait;
 }

--- a/tests/ConstructNamedParameters/Samples/FooCreatable.php
+++ b/tests/ConstructNamedParameters/Samples/FooCreatable.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\ConstructNamedParameters\Samples;
 
 use ConstructNamedParameters\Traits\StaticCreateTrait;

--- a/tests/ConstructNamedParameters/Samples/FooCreatable.php
+++ b/tests/ConstructNamedParameters/Samples/FooCreatable.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Tests\ConstructNamedParameters\Samples;
 
 use ConstructNamedParameters\Traits\StaticCreateTrait;

--- a/tests/ConstructNamedParameters/Traits/StaticCreateIgnoreCaseTraitTest.php
+++ b/tests/ConstructNamedParameters/Traits/StaticCreateIgnoreCaseTraitTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Tests\ConstructNamedParameters\Traits;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ConstructNamedParameters/Traits/StaticCreateIgnoreCaseTraitTest.php
+++ b/tests/ConstructNamedParameters/Traits/StaticCreateIgnoreCaseTraitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\ConstructNamedParameters\Traits;
+
+use PHPUnit\Framework\TestCase;
+use Tests\ConstructNamedParameters\Samples\BarCreatable;
+
+class StaticCreateIgnoreCaseTraitTest extends TestCase
+{
+    public function testCreateMethod()
+    {
+        $values = [
+            'SecondArgument' => 222,
+            'FIRSTargument' => 'first',
+        ];
+        $third = 'BAZ';
+
+        $foo = BarCreatable::create($values);
+        $this->assertSame($values['FIRSTargument'], $foo->getFirst());
+        $this->assertSame($values['SecondArgument'], $foo->getSecond());
+        $this->assertSame($third, $foo->getThird());
+    }
+}


### PR DESCRIPTION
- This does **not break** compatibility with 1.0.0  
- Add interface `CreatableFromArrayInterface` that enforces an static method create(array): $this 
- Add interface `ExportableToArrayInterface` that enforces an method toArray(): array 
- Add trait `StaticCreateIgnoreCaseTrait`, is the same as `StaticCreateTrait` but ignore case on keys 
- More test for all changes 